### PR TITLE
Área de texto procesado y estilos de pop-up

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ const divValidaciones = document.querySelector(".div_validaciones");
 const divError = document.querySelector(".msjValidacion");
 const aside = document.querySelector("aside");
 const textoAside = document.getElementById("texto_aside");
-const areaMostrarMensaje = document.querySelector("span");
+const areaTextoFinal = document.getElementById("areaTextoFinal");
 const imgAside = document.getElementById("img_aside");
 const divLeyendas = document.getElementById("leyendas");
 const leyendaSinMsj = document.getElementById("leyendaSinMsj");
@@ -43,6 +43,15 @@ let contErrores = 0;
 let contCheck = false;
 let flagCheck = false;
 let arrayFlags = [contErrores, flagCheck, contCheck];
+
+//Configuración de Toastr
+toastr.options = {
+  "newestOnTop": true,
+  "progressBar": true,
+  "positionClass": "toast-top-center",
+  "showDuration": "300",
+   "timeOut": "2000"
+};
 
 //Creacion de elementos HTML
 // Mensaje de texto valido
@@ -161,8 +170,9 @@ function desencriptar() {
 
 function mostrarMensaje(mensaje) {
   aside.style.justifyContent = "space-between";
-  areaMostrarMensaje.style.display = "block";
-  areaMostrarMensaje.innerHTML = mensaje;
+  textoAside.style.height = "100%"
+  areaTextoFinal.style.display = "block";
+  areaTextoFinal.value = mensaje;
   btnCopiar.style.display = "block";
   imgAside.style.display = "none";
   divLeyendas.style.display = "none";
@@ -184,7 +194,7 @@ async function copiarTexto() {
 
 function mensajeVacio() {
   aside.style.justifyContent = "center";
-  areaMostrarMensaje.style.display = "none";
+  areaTextoFinal.style.display = "none";
   btnCopiar.style.display = "none";
   imgAside.style.display = "block";
   imgAside.style.margin = "0px auto";
@@ -242,23 +252,28 @@ async function traducirTexto(a, b) {
     )}&langpair=${a}|${b}`
   );
   const data = await response.json();
-  textoTraducido = data.matches[0].translation.toLowerCase();
-  textoUsuario.value = textoTraducido;
+  if (data.matches.length>0) {
+    textoTraducido = data.matches[0].translation.toLowerCase();
+    textoUsuario.value = textoTraducido;
+  } else {
+    textoTraducido = data.responseDetails;
+    toastr.error("HAS EXCEDIDO EL LIMITE. CONSULTA MÁXIMA PERMITIDA: 500 CARACTERES")
+  }
   return textoTraducido;
 }
 
 function ampliarFuente() {
   if (cont == 0) {
     textoUsuario.style.fontSize = "28px";
-    areaMostrarMensaje.style.fontSize = "28px";
+    areaTextoFinal.style.fontSize = "28px";
     cont = 1;
   } else if (cont == 1) {
     textoUsuario.style.fontSize = "38px";
-    areaMostrarMensaje.style.fontSize = "38px";
+    areaTextoFinal.style.fontSize = "38px";
     cont = 2;
   } else {
     textoUsuario.style.fontSize = "18px";
-    areaMostrarMensaje.style.fontSize = "18px";
+    areaTextoFinal.style.fontSize = "18px";
     cont = 0;
   }
   return cont;
@@ -371,7 +386,7 @@ buttonPT.addEventListener("mouseout", (event) => {
 buttonPT.addEventListener("click", (event) => {
   event.preventDefault();
   if (textoUsuario.value == "") {
-    alert("TEXTO VACIO..!!! Ingresa un texto por favor...");
+    toastr.error("Ingresa un texto por favor...","TEXTO VACIO..!!!");
   } else {
     traducirTexto(es, pt);
   }
@@ -389,7 +404,7 @@ buttonES.addEventListener("mouseout", (event) => {
 buttonES.addEventListener("click", (event) => {
   event.preventDefault();
   if (textoUsuario.value == "") {
-    alert("TEXTO VACIO..!!! Ingresa un texto por favor...");
+    toastr.error("Ingresa un texto por favor...","TEXTO VACIO..!!!");
   } else {
     traducirTexto(pt, es);
   }
@@ -407,7 +422,7 @@ buttonTt.addEventListener("mouseout", (event) => {
 buttonTt.addEventListener("click", (event) => {
   event.preventDefault();
   if (textoUsuario.value == "") {
-    alert("TEXTO VACIO..!!! Ingresa un texto por favor...");
+    toastr.error("Ingresa un texto por favor...","TEXTO VACIO..!!!");
   } else {
     ampliarFuente();
   }
@@ -425,8 +440,9 @@ buttonHead.addEventListener("mouseout", (event) => {
 buttonHead.addEventListener("click", (event) => {
   event.preventDefault();
   if (textoUsuario.value == "") {
-    alert("TEXTO VACIO..!!! Ingresa un texto por favor...");
+    toastr.error("Ingresa un texto por favor...","TEXTO VACIO..!!!");
   } else {
     scanearErrores(texto);
   }
 });
+

--- a/css/general.css
+++ b/css/general.css
@@ -11,13 +11,16 @@
 }
 body {
   background-color: #e5e5e5;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 main {
   width: 100%;
   margin: auto;
   padding: 0% 5%;
 }
-a {
+a { 
   text-decoration: none;
   color: #000;
 }
@@ -25,7 +28,7 @@ a:hover {
   color: white;
   text-decoration: dotted;
 }
-textarea {
+#areaTextoUsuario {
   padding: 15px;
   width: 100%;
   max-width: 100%;
@@ -36,10 +39,23 @@ textarea {
   border: none;
   outline: none;
   transition: border-color 1s, box-shadow 0.5s, background-color 0.5s;
-  overflow-y: hidden;
+  overflow-y: auto;
   resize: none;
 }
-textarea:focus {
+#areaTextoFinal {
+  padding: 15px;
+  width: 100%;
+  height: 100%;
+  font-size: 18px;
+  background-color: #ffffff;
+  border-radius: 30px;
+  border: none;
+  outline: none;
+  overflow-y:auto;
+  resize: none;
+  display: none;
+}
+#areaTextoUsuario:focus {
   background-color: #ffffff;
   box-shadow: 5px 5px rgba(10, 56, 113, 0.2);
 }
@@ -126,7 +142,7 @@ footer i {
   aside {
     padding: 25px 60px;
   }
-  textarea {
+  #areaTextoUsuario {
     height: 500px;
   }
   footer {

--- a/css/style.css
+++ b/css/style.css
@@ -15,6 +15,9 @@
     height: auto;
     cursor: pointer;
   }
+  #list_icon_burger {
+    display: none;
+  }
   .box_list {
     margin: 10px auto;
     padding: 5px 0px;
@@ -229,4 +232,10 @@
   100% {
     opacity: 0%;
   }
+}
+
+.toast-error {
+  background-color: red ; 
+  color: #FFFFFF; 
+  text-align: center
 }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet">
+  <!-- Incluye jQuery -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+  <!-- Incluye Toastr CSS -->
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" rel="stylesheet">
+  <!-- Incluye Toastr JS -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
   <link rel="stylesheet" href="./css/general.css">
 </head>
 
@@ -45,7 +51,7 @@
     </section>
     <section class="section_segunda">
       <p id="tituloIngreseTexto">Ingrese el texto aqui...</p>
-      <textarea name="" id="areaTextoUsuario" maxlength="2000"></textarea>
+      <textarea name="" id="areaTextoUsuario" maxlength="500"></textarea>
       <div class="div_validaciones">
         <div class="msjValidacion">
           <i class="fa-solid fa-circle-exclamation" id="iconoExclamacion"></i>
@@ -59,9 +65,7 @@
     </section>
     <aside>
       <div id="texto_aside">
-        <span>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quibusdam, aliquid! Dolorum debitis quasi
-          pariatur omnis dolore dignissimos reprehenderit, nobis aut quisquam hic. Laborum cum corporis veritatis
-          itaque, similique enim et!</span>
+        <textarea name="" id="areaTextoFinal" maxlength="2000" readonly></textarea>
       </div>
       <div class="div_img_aside" id="img_aside">
         <img src="./img/img-personaBuscando.png" alt="persona buscando con una lupa" id="img-personaBuscando">


### PR DESCRIPTION
En esta integración:
Cambie los alert() por una alternativa de pop-up de la librería Toastr.
Cambie el área donde se mostraba el texto encriptado/desencriptado de un span a un textarea.
Modifique las funciones donde infería el antiguo span.
Ajuste valores de flexbox de las etiquetas body y main.
